### PR TITLE
Fix bug due to wrong file name

### DIFF
--- a/modules/local/assign_feelnc_biotype.nf
+++ b/modules/local/assign_feelnc_biotype.nf
@@ -54,7 +54,7 @@ process ASSIGN_FEELNC_BIOTYPE {
                         print \$0
                     }
                 }
-            ' exons."\$biotype".gtf novel.feelnc_biotype.gff > tmp.gff
+            ' feelnc.predicted."\$biotype".gtf novel.feelnc_biotype.gff > tmp.gff
             mv tmp.gff novel.feelnc_biotype.gff
         fi
     done


### PR DESCRIPTION
Process `ASSIGN_FEELNC_BIOTYPE` has an input to the awk program incorrectly named.

<!--
# nf-core/rnaseq pull request

Many thanks for contributing to nf-core/rnaseq!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/rnaseq/tree/master/.github/CONTRIBUTING.md)
-->
<!-- markdownlint-disable ul-indent -->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
    - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/rnaseq/tree/master/.github/CONTRIBUTING.md)
    - [ ] If necessary, also make a PR on the nf-core/rnaseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint .`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
